### PR TITLE
Crack dat refresh

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -183,7 +183,7 @@ android {
 
         droidconit {
             applicationId = "com.conferenceengineer.android.iosched.droidconit2015"
-            uniqueContentIdentifier = "droidconit"
+            uniqueContentIdentifier = "droidconit2015"
             manifestPlaceholders = [
                     uniqueContentIdentifier:uniqueContentIdentifier,
                     mapsApiKey:droidconit15_android_maps_api_key

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -200,7 +200,7 @@ android {
             buildConfigField "double", "VENUE_CAMERA_LONGITUDE", "7.664791"
 
             buildConfigField "String", "CONFERENCE_NAME", "\"Droidcon Italy 2015\""
-            buildConfigField "String", "CONFERENCE_DATA_MANIFEST_URL", "\""+droidconit15_android_manifest+"\""
+            buildConfigField "String", "CONFERENCE_DATA_MANIFEST_URL", "\"http://it.droidcon.com/2015/wp-content/uploads/data.json\""
             buildConfigField "String", "OAUTH_APP_NAME", "\"DroidconUK2014-2014\""
             buildConfigField "String", "OAUTH_API_KEY", "\""+droidconit15_android_oauth_api_key+"\""
             buildConfigField "String", "GCM_API_KEY", "\""+droidconit15_gcm_api_key+"\""

--- a/android/src/main/java/com/google/samples/apps/iosched/sync/RemoteConferenceDataFetcher.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/sync/RemoteConferenceDataFetcher.java
@@ -80,24 +80,27 @@ public class RemoteConferenceDataFetcher extends ServerDataFetcher {
      * @throws IOException if an error occurred during download.
      */
     public String[] fetchConferenceDataIfNewer(String refTimestamp) throws IOException {
-        if (TextUtils.isEmpty(mManifestUrl)) {
-            LOGW(TAG, "Manifest URL is empty (remote sync disabled!).");
-            return null;
-        }
+        //if (TextUtils.isEmpty(mManifestUrl)) {
+        //    LOGW(TAG, "Manifest URL is empty (remote sync disabled!).");
+        //    return null;
+        //}
+        //
+        //String manifestData = fetchDataIfNewer(TAG, mManifestUrl, refTimestamp);
+        //if(manifestData == null) {
+        //    LOGD(TAG, "No new data is available");
+        //    return null;
+        //}
+        //
+        //if (TextUtils.isEmpty(manifestData)) {
+        //    LOGE(TAG, "Request for manifest returned empty data.");
+        //    throw new IOException("Error fetching conference data manifest: no data.");
+        //}
+        //LOGD(TAG, "Manifest "+mManifestUrl+" read, contents: " + manifestData);
+        //mBytesDownloaded += manifestData.getBytes().length;
+        //return processManifest(manifestData);
 
-        String manifestData = fetchDataIfNewer(TAG, mManifestUrl, refTimestamp);
-        if(manifestData == null) {
-            LOGD(TAG, "No new data is available");
-            return null;
-        }
-
-        if (TextUtils.isEmpty(manifestData)) {
-            LOGE(TAG, "Request for manifest returned empty data.");
-            throw new IOException("Error fetching conference data manifest: no data.");
-        }
-        LOGD(TAG, "Manifest "+mManifestUrl+" read, contents: " + manifestData);
-        mBytesDownloaded += manifestData.getBytes().length;
-        return processManifest(manifestData);
+        LOGD(TAG, "Not using Manifest at all! See RemoteConferenceDataFetcher.fetchConferenceDataIfNewer(String).");
+        return new String[] { fetchFile(getManifestUrl()) };
     }
 
     /**
@@ -147,21 +150,23 @@ public class RemoteConferenceDataFetcher extends ServerDataFetcher {
 
         LOGD(TAG, "Attempting to fetch: " + sanitizeUrl(url));
 
-        // Check if we have it in our cache first
         String body;
-        try {
-            body = loadFromCache(url);
-            if (!TextUtils.isEmpty(body)) {
-                // cache hit
-                mBytesReadFromCache += body.getBytes().length;
-                mCacheFilesToKeep.add(getCacheKey(url));
-                return body;
-            }
-        } catch (IOException ex) {
-            ex.printStackTrace();
-            LOGE(TAG, "IOException getting file from cache.");
-            // proceed anyway to attempt to download it from the network
-        }
+
+        LOGD(TAG, "Caching is disabled! See RemoteConferenceDataFetcher.fetchFile(String).");
+        //// Check if we have it in our cache first
+        //try {
+        //    body = loadFromCache(url);
+        //    if (!TextUtils.isEmpty(body)) {
+        //        // cache hit
+        //        mBytesReadFromCache += body.getBytes().length;
+        //        mCacheFilesToKeep.add(getCacheKey(url));
+        //        return body;
+        //    }
+        //} catch (IOException ex) {
+        //    ex.printStackTrace();
+        //    LOGE(TAG, "IOException getting file from cache.");
+        //    // proceed anyway to attempt to download it from the network
+        //}
 
         // We don't have the file on cache, so download it
         LOGD(TAG, "Cache miss. Downloading from network: " + sanitizeUrl(url));
@@ -181,8 +186,8 @@ public class RemoteConferenceDataFetcher extends ServerDataFetcher {
             }
             LOGD(TAG, "Successfully downloaded from network: " + sanitizeUrl(url));
             mBytesDownloaded += body.getBytes().length;
-            writeToCache(url, body);
-            mCacheFilesToKeep.add(getCacheKey(url));
+            //writeToCache(url, body);
+            //mCacheFilesToKeep.add(getCacheKey(url));
             return body;
         } else {
             LOGE(TAG, "Failed to fetch from network: " + sanitizeUrl(url));

--- a/android/src/main/java/com/google/samples/apps/iosched/ui/BaseActivity.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/ui/BaseActivity.java
@@ -270,19 +270,17 @@ public abstract class BaseActivity extends ActionBarActivity implements
     private void trySetupSwipeRefresh() {
         mSwipeRefreshLayout = (SwipeRefreshLayout) findViewById(R.id.swipe_refresh_layout);
         if (mSwipeRefreshLayout != null) {
-//            mSwipeRefreshLayout.setColorScheme(
-//                    R.color.refresh_progress_1,
-//                    R.color.refresh_progress_2,
-//                    R.color.refresh_progress_3,
-//                    R.color.refresh_progress_4);
-//            mSwipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
-//                @Override
-//                public void onRefresh() {
-//                    requestDataRefresh();
-//                }
-//            });
-
-            mSwipeRefreshLayout.setEnabled(false);
+            mSwipeRefreshLayout.setColorScheme(
+                    R.color.refresh_progress_1,
+                    R.color.refresh_progress_2,
+                    R.color.refresh_progress_3,
+                    R.color.refresh_progress_4);
+            mSwipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
+                @Override
+                public void onRefresh() {
+                    requestDataRefresh();
+                }
+            });
 
             if (mSwipeRefreshLayout instanceof MultiSwipeRefreshLayout) {
                 MultiSwipeRefreshLayout mswrl = (MultiSwipeRefreshLayout) mSwipeRefreshLayout;

--- a/android/src/main/res/menu/browse_sessions.xml
+++ b/android/src/main/res/menu/browse_sessions.xml
@@ -22,10 +22,10 @@
         android:title="@string/description_search"
         iosched:showAsAction="always" />
 
-    <!--<item android:id="@+id/menu_refresh"-->
-        <!--android:orderInCategory="1"-->
-        <!--android:title="@string/description_refresh"-->
-        <!--iosched:showAsAction="never" />-->
+    <item android:id="@+id/menu_refresh"
+        android:orderInCategory="1"
+        android:title="@string/description_refresh"
+        iosched:showAsAction="never" />
 
     <item android:id="@+id/menu_wifi"
         android:orderInCategory="98"

--- a/android/src/main/res/xml/syncadapter.xml
+++ b/android/src/main/res/xml/syncadapter.xml
@@ -16,7 +16,7 @@
 
 <!-- The attributes in this XML file provide configuration information for the SyncAdapter. -->
 <sync-adapter xmlns:android="http://schemas.android.com/apk/res/android"
-    android:contentAuthority="com.google.samples.apps.iosched"
+    android:contentAuthority="com.conferenceengineer.android.iosched.droidconit2015"
     android:accountType="com.google"
     android:supportsUploading="false"
     android:userVisible="true" />


### PR DESCRIPTION
###### This is an _abomination_, required given the little time and impossibility to get the json (and manifest) in the correct format.

Here's an attempt to hack the "manifest" mechanism (see [here](https://github.com/rock3r/iosched/blob/5fb5c2d55d53a57b215e51d313b0459c7c718668/doc/SYNC.md#sync-protocol-and-data-format)) into loading the json directly from the same url, without caching (as we don't change the name of the file every time).
