### PR TITLE
Special sessions

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -18,8 +18,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="com.google.samples.apps.iosched"
-    android:versionCode="201504"
-    android:versionName="2015.04"
+    android:versionCode="20150409"
+    android:versionName="2015.04.09"
     android:installLocation="auto">
 
     <uses-sdk

--- a/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
@@ -192,7 +192,8 @@ public final class JsonTransformer {
         final String roomName = escapeHtml(di15Session.location);
         if (BLOCK_SESSIONS.contains(di15Session.url)) {
             addBlock(di15Session.post_title,
-                    roomName, di15Session.date,
+                    roomName,
+                    di15Session.date,
                     di15Session.time,
                     di15Session.end_time,
                     false,

--- a/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
@@ -58,8 +58,7 @@ public final class JsonTransformer {
         SPECIAL_SESSIONS.add("http://it.droidcon.com/2015/sessions/barcamp-organization-2/");
         SPECIAL_SESSIONS.add("http://it.droidcon.com/2015/sessions/droidcon-party/");
 
-        final int NUMBER_OF_ROOMS = 8;
-        ROOMS_TO_COLORS = new HashMap<>(NUMBER_OF_ROOMS);
+        ROOMS_TO_COLORS = new HashMap<>(8);
         ROOMS_TO_COLORS.put("sala 500", "#8e24aa");
         ROOMS_TO_COLORS.put("sala lisbona", "#2a56c6");
         ROOMS_TO_COLORS.put("sala londra", "#558b2f");

--- a/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
@@ -188,8 +188,10 @@ public final class JsonTransformer {
 
         // *** BLOCKS ***
 
+        final String sessionUrl =
+                di15Session.url == null ? null : di15Session.url.toLowerCase(Locale.US);
         final String roomName = escapeHtml(di15Session.location);
-        if (BLOCK_SESSIONS.contains(di15Session.url)) {
+        if (sessionUrl != null && BLOCK_SESSIONS.contains(sessionUrl)) {
             addBlock(di15Session.post_title,
                     roomName,
                     di15Session.date,
@@ -235,7 +237,7 @@ public final class JsonTransformer {
 
         final List<String> di15Tags =
                 di15Session.track != null ? di15Session.track : new ArrayList<String>();
-        if (SPECIAL_SESSIONS.contains(di15Session.url)) {
+        if (sessionUrl != null && SPECIAL_SESSIONS.contains(sessionUrl)) {
             di15Tags.add(Config.Tags.SPECIAL_KEYNOTE);
         }
         for (String di15tag : di15Tags) {
@@ -250,10 +252,10 @@ public final class JsonTransformer {
         // *** SESSIONS ***
 
         final Session session = new Session();
-        session.id = di15Session.url;
+        session.id = sessionUrl;
         session.title = escapeHtml(di15Session.post_title);
         session.description = escapeHtml(di15Session.content);
-        session.url = di15Session.url;
+        session.url = sessionUrl;
         session.room = roomName;
         session.color = getColorFrom(roomName);
         session.tags = di15Tags.toArray(new String[di15Tags.size()]);

--- a/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
@@ -388,8 +388,7 @@ public final class JsonTransformer {
      * From html to plain text, yo.
      */
     @Nullable
-    private static String escapeHtml(@Nullable String html)
-    {
+    private static String escapeHtml(@Nullable String html) {
         return html == null ? null : Html.fromHtml(html).toString(); // THE HORROR
     }
 }

--- a/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
+++ b/android/src/main/java/com/google/samples/apps/iosched/droidconitaly15/JsonTransformer.java
@@ -271,7 +271,7 @@ public final class JsonTransformer {
             return DEFAULT_ROOM_COLOR;
         }
 
-        String roomColor = ROOMS_TO_COLORS.get(roomName.trim().toLowerCase());
+        String roomColor = ROOMS_TO_COLORS.get(roomName.trim().toLowerCase(Locale.US));
 
         if (roomColor == null) {
             roomColor = DEFAULT_ROOM_COLOR;


### PR DESCRIPTION
So I was expecting the Json to be updated with more information (like blocks), but that's not happening so I'm changing the way we handle blocks a bit. 

Changes:
- Sessions like "Barcamp organization" or "Droidcon Party" are just like the Keynote: you can't add them as they always appear in the schedule (also, they are now colored) and you can see the description if you click on them. It also means that they are now in the list with all the other sessions. Deal with it.
- Some of the "break" blocks are now populated by the json, which means that they can be updated remotely. Hurray \o/

![CRUSHED IT](https://cloud.githubusercontent.com/assets/2116164/6993086/350833b2-dae9-11e4-922d-df82a36e9d83.gif)
